### PR TITLE
Fix panic when parsing pairs

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -81,9 +81,14 @@ func ParseList(value string) []string {
 func ParsePairs(value string) map[string]string {
 	m := make(map[string]string)
 	for _, pair := range ParseList(strings.TrimSpace(value)) {
-		if i := strings.Index(pair, "="); i < 0 {
+		switch i := strings.Index(pair, "="); {
+		case i < 0:
+			// No '=' in pair, treat whole string as a 'key'.
 			m[pair] = ""
-		} else {
+		case i == len(pair)-1:
+			// Malformed pair ('key=' with no value), keep key with empty value.
+			m[pair[:i]] = ""
+		default:
 			v := pair[i+1:]
 			if v[0] == '"' && v[len(v)-1] == '"' {
 				// Unquote it.

--- a/misc_test.go
+++ b/misc_test.go
@@ -17,7 +17,7 @@ func TestH(t *testing.T) {
 
 func TestParsePairs(t *testing.T) {
 	t.Parallel()
-	const header = `username="\test", realm="a \"quoted\" string", nonce="FRPnGdb8lvM1UHhi", uri="/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro", algorithm=MD5, response="fdcdd78e5b306ffed343d0ec3967f2e5", opaque="lEgVjogmIar2fg/t", qop=auth, nc=00000001, cnonce="e76b05db27a3b323"`
+	const header = `username="\test", realm="a \"quoted\" string", nonce="FRPnGdb8lvM1UHhi", uri="/css?family=Source+Sans+Pro:400,700,400italic,700italic|Source+Code+Pro", algorithm=MD5, response="fdcdd78e5b306ffed343d0ec3967f2e5", opaque="lEgVjogmIar2fg/t", qop=auth, nc=00000001, cnonce="e76b05db27a3b323", empty1=, empty2=""`
 
 	want := map[string]string{
 		"username":  "test",
@@ -30,6 +30,8 @@ func TestParsePairs(t *testing.T) {
 		"qop":       "auth",
 		"nc":        "00000001",
 		"cnonce":    "e76b05db27a3b323",
+		"empty1":    "",
+		"empty2":    "",
 	}
 	got := ParsePairs(header)
 


### PR DESCRIPTION
This PR updates the fork with the last changes to fix the panic on parsing pairs.

Edit: the last commit: https://github.com/abbot/go-http-auth/commit/d3faa315ed8c8d4d7e5a127c0345b42b60b58872, related to the PR https://github.com/abbot/go-http-auth/pull/73